### PR TITLE
bump version to 0.1.0-alpha.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
         - cargo update
         - cargo test
         - cargo fmt -- --check
+        - if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-}" = release-* ]]; then cargo package; fi
 
     - rust: nightly
       env: LATEST_NIGHTLY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finchers-juniper"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 description = """
 Endpoints for supporting Juniper integration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! Endpoints for supporting Juniper integration.
 
 #![doc(
-    html_root_url = "https://docs.rs/finchers-juniper/0.1.0-alpha.2",
+    html_root_url = "https://docs.rs/finchers-juniper/0.1.0-alpha.3",
     test(attr(feature(rust_2018_preview))),
 )]
 #![warn(


### PR DESCRIPTION
* bump juniper to 0.10.0 (6394823)
* add option to `execute_nonblocking()` for setting whether to use tokio's blocking API (6807223)
* make `GraphQLRequest::execute_async()` deprecated (0cc53e8)